### PR TITLE
Fix double slash in API URL's causing the plugin to never work

### DIFF
--- a/Jellyfin.Plugin.Vgmdb/VgmdbApi.cs
+++ b/Jellyfin.Plugin.Vgmdb/VgmdbApi.cs
@@ -10,7 +10,7 @@ namespace Jellyfin.Plugin.Vgmdb;
 
 public class VgmdbApi
 {
-    private const string RootUrl = @"https://vgmdb.info/";
+    private const string RootUrl = @"https://vgmdb.info";
     private readonly IHttpClientFactory _httpClientFactory;
 
     public VgmdbApi(IHttpClientFactory httpClientFactory)


### PR DESCRIPTION
Basically a search request would use the following URL:

`https://vgmdb.info//search?format=json&q=`

Because the RootUrl ends with a slash and when adding the path we start with a slash. This would cause the API to respond with a 404 response containing HTML content.

Fixes #16