### PR TITLE
Make the API server URL configurable

### DIFF
--- a/Jellyfin.Plugin.Vgmdb/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Vgmdb/Configuration/configPage.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>VGMdb</title>
+</head>
+<body>
+<div id="VgmdbConfigPage" data-role="page" class="page type-interior pluginConfigurationPage">
+    <div data-role="content">
+        <div class="content-primary">
+            <form id="VgmdbConfigForm">
+                <div class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="ServerUrl">Server URL</label>
+                    <input id="ServerUrl" name="ServerUrl" type="url" is="emby-input" required />
+                    <div class="fieldDescription">
+                        Base URL of the VGMdb API to query. Defaults to
+                        https://vgmdb.info, the public instance. Point this at a
+                        self-hosted deployment of hufman/vgmdb &mdash; for example
+                        http://192.168.1.10:8085 &mdash; if the public one is
+                        unavailable. No trailing slash needed.
+                    </div>
+                </div>
+                <div>
+                    <button is="emby-button" type="submit" class="raised button-submit block emby-button">
+                        <span>Save</span>
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <script type="text/javascript">
+        var VgmdbPluginConfig = {
+            uniqueId: '44616595-5798-47ad-8658-3c09f3030505'
+        };
+
+        document.querySelector('#VgmdbConfigPage')
+            .addEventListener('pageshow', function () {
+                Dashboard.showLoadingMsg();
+                ApiClient.getPluginConfiguration(VgmdbPluginConfig.uniqueId).then(function (config) {
+                    document.querySelector('#ServerUrl').value = config.ServerUrl || '';
+                    Dashboard.hideLoadingMsg();
+                });
+            });
+
+        document.querySelector('#VgmdbConfigForm')
+            .addEventListener('submit', function (e) {
+                e.preventDefault();
+                Dashboard.showLoadingMsg();
+                ApiClient.getPluginConfiguration(VgmdbPluginConfig.uniqueId).then(function (config) {
+                    config.ServerUrl = document.querySelector('#ServerUrl').value;
+                    ApiClient.updatePluginConfiguration(VgmdbPluginConfig.uniqueId, config).then(function (result) {
+                        Dashboard.processPluginConfigurationUpdateResult(result);
+                    });
+                });
+                return false;
+            });
+    </script>
+</div>
+</body>
+</html>

--- a/Jellyfin.Plugin.Vgmdb/Jellyfin.Plugin.Vgmdb.csproj
+++ b/Jellyfin.Plugin.Vgmdb/Jellyfin.Plugin.Vgmdb.csproj
@@ -15,6 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="Configuration\configPage.html" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
     <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />

--- a/Jellyfin.Plugin.Vgmdb/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Vgmdb/PluginConfiguration.cs
@@ -5,4 +5,15 @@ namespace Jellyfin.Plugin.Vgmdb;
 /// <inheritdoc />
 public class PluginConfiguration : BasePluginConfiguration
 {
+    /// <summary>
+    /// Gets or sets the base URL of the VGMdb API server.
+    /// </summary>
+    /// <remarks>
+    /// The backend was previously a compile-time constant pointing at
+    /// https://vgmdb.info, so there was no way to redirect the plugin when
+    /// that host became unreachable. Any deployment of hufman/vgmdb serves
+    /// the same endpoints, so pointing this at a self-hosted instance works
+    /// without any other change.
+    /// </remarks>
+    public string ServerUrl { get; set; } = "https://vgmdb.info";
 }

--- a/Jellyfin.Plugin.Vgmdb/VgmdbApi.cs
+++ b/Jellyfin.Plugin.Vgmdb/VgmdbApi.cs
@@ -10,12 +10,35 @@ namespace Jellyfin.Plugin.Vgmdb;
 
 public class VgmdbApi
 {
-    private const string RootUrl = @"https://vgmdb.info";
+    private const string DefaultRootUrl = @"https://vgmdb.info";
     private readonly IHttpClientFactory _httpClientFactory;
 
     public VgmdbApi(IHttpClientFactory httpClientFactory)
     {
         _httpClientFactory = httpClientFactory;
+    }
+
+    /// <summary>
+    /// Gets the configured server URL, falling back to the public instance.
+    /// </summary>
+    /// <remarks>
+    /// Read per request rather than cached, so changing it on the plugin
+    /// configuration page takes effect without restarting the server. Any
+    /// trailing slash is trimmed because every caller appends an absolute
+    /// path, and "host//album/1" would 404.
+    /// </remarks>
+    private static string RootUrl
+    {
+        get
+        {
+            var configured = VgmdbPlugin.Instance?.Configuration?.ServerUrl;
+            if (string.IsNullOrWhiteSpace(configured))
+            {
+                return DefaultRootUrl;
+            }
+
+            return configured.Trim().TrimEnd('/');
+        }
     }
 
     public async Task<ArtistResponse> GetArtistByIdAsync(int id, CancellationToken cancellationToken)

--- a/Jellyfin.Plugin.Vgmdb/VgmdbPlugin.cs
+++ b/Jellyfin.Plugin.Vgmdb/VgmdbPlugin.cs
@@ -1,21 +1,44 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
+using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Serialization;
 
 namespace Jellyfin.Plugin.Vgmdb;
 
 /// <inheritdoc />
-public class VgmdbPlugin : BasePlugin<PluginConfiguration>
+public class VgmdbPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
 {
     public VgmdbPlugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer)
         : base(applicationPaths, xmlSerializer)
     {
+        Instance = this;
     }
+
+    /// <summary>
+    /// Gets the current plugin instance, so the API client can read the
+    /// configured server URL.
+    /// </summary>
+    public static VgmdbPlugin Instance { get; private set; }
 
     /// <inheritdoc />
     public override string Name => "VGMdb";
 
     /// <inheritdoc />
     public override Guid Id => Guid.Parse("44616595-5798-47ad-8658-3c09f3030505");
+
+    /// <inheritdoc />
+    public IEnumerable<PluginPageInfo> GetPages()
+    {
+        yield return new PluginPageInfo
+        {
+            Name = Name,
+            EmbeddedResourcePath = string.Format(
+                CultureInfo.InvariantCulture,
+                "{0}.Configuration.configPage.html",
+                GetType().Namespace),
+        };
+    }
 }


### PR DESCRIPTION
The API backend is a compile-time constant:

```csharp
private const string RootUrl = @"https://vgmdb.info";
```

That host is currently unreachable — it does not answer at all, so every album, artist and search lookup fails. Because the URL is a `const` and `PluginConfiguration` is empty, there is no way for a user to point the plugin at a working server.

This moves the URL into plugin configuration and adds a configuration page to edit it. It is read per request rather than cached, so a change takes effect without restarting the server, and a trailing slash is trimmed since every caller appends an absolute path.

The default is unchanged, so nothing differs for anyone the public instance still works for.

Any deployment of [hufman/vgmdb](https://github.com/hufman/vgmdb) serves the same endpoints, so pointing this at a self-hosted instance is all that is required. Verified against one — the three endpoints the plugin calls (`/album/{id}?format=json`, `/artist/{id}?format=json`, `/search?format=json&q=`) all return the expected shapes, so no response handling changes were needed.
